### PR TITLE
fix(const): seralized

### DIFF
--- a/server/bundle.js
+++ b/server/bundle.js
@@ -13,7 +13,7 @@ const BLACKLIST = [
 const MAX_DISTINCT_TO = 2
 
 function checkBlacklistTx(rawTx) {
-  const tx = Transaction.fromRlpSerializedTx(rawTx)
+  const tx = Transaction.fromSerializedTx(rawTx)
 
   return (tx.to && _.includes(BLACKLIST, tx.to.toString())) || _.includes(BLACKLIST, tx.getSenderAddress().toString())
 }


### PR DESCRIPTION

currently,fromRlpSerializedTx is used to instantiate a transaction from the serialized tx.
```js
 const tx = Transaction.fromRlpSerializedTx(rawTx)
```

this constructor alias is deprecated and will be removed in favor of the fromSerializedTx() constructor

If we look at the `@types/` we find

(6387) legacyTransaction.d.ts(21, 8): The declaration was marked as deprecated (here: 21, 8)