### PR TITLE
Switch from parseTransaction to [faster] ethereumjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@sentry/node": "^5.29.2",
     "body-parser": "^1.19.0",
     "dynamoose": "^2.7.0",
+    "@ethereumjs/tx": "3.1.4",
     "ethers": "5.1.3",
     "express": "^4.17.1",
     "express-prom-bundle": "^6.3.1",

--- a/server/bundle.js
+++ b/server/bundle.js
@@ -1,6 +1,7 @@
 const { TransactionFactory } = require('@ethereumjs/tx')
 const _ = require('lodash')
 const Common = require('@ethereumjs/common').default
+const { arrayify } = require('ethers/lib/utils')
 
 const commonOpts = new Common({ chain: process.env.CHAIN_NAME || 'mainnet' })
 
@@ -45,7 +46,7 @@ function checkDistinctAddresses(txs) {
 function getParsedTransactions(rawTxs) {
   const parsedTransactions = []
   rawTxs.forEach((rawTx) => {
-    TransactionFactory.fromSerializedData(Buffer.from(rawTx, 'hex'), { common: commonOpts })
+    TransactionFactory.fromSerializedData(arrayify(rawTx), { common: commonOpts })
     parsedTransactions.push()
   })
   return parsedTransactions

--- a/server/handlers.js
+++ b/server/handlers.js
@@ -118,12 +118,13 @@ class Handler {
     if (!Array.isArray(bundle)) {
       bundle = bundle.txs
     }
+    const parsedTransactions = getParsedTransactions(bundle)
     try {
-      if (checkBlacklist(bundle)) {
-        console.error(`bundle was interacting with blacklisted address: ${bundle}`)
+      if (checkBlacklist(parsedTransactions)) {
+        console.error(`bundle was interacting with blacklisted address: ${parsedTransactions}`)
         writeError(res, 400, 'blacklisted tx')
         return
-      } else if (checkDistinctAddresses(bundle)) {
+      } else if (checkDistinctAddresses(parsedTransactions)) {
         console.error(`bundle interacted with more than ${MAX_DISTINCT_TO} addresses`)
         writeError(res, 400, `bundle interacted with more than ${MAX_DISTINCT_TO} addresses`)
         return

--- a/server/handlers.js
+++ b/server/handlers.js
@@ -5,7 +5,7 @@ const AWS = require('aws-sdk')
 const postgres = require('postgres')
 
 const { writeError } = require('./utils')
-const { checkBlacklist, checkDistinctAddresses, MAX_DISTINCT_TO } = require('./bundle')
+const { checkBlacklist, checkDistinctAddresses, getParsedTransactions, MAX_DISTINCT_TO } = require('./bundle')
 
 class Handler {
   constructor(MINERS, SIMULATION_RPC, SQS_URL, PSQL_DSN, promClient) {
@@ -36,11 +36,12 @@ class Handler {
     }
 
     try {
-      if (checkBlacklist(txs)) {
+      const parsedTransactions = getParsedTransactions(txs)
+      if (checkBlacklist(parsedTransactions)) {
         console.error(`txs was interacting with blacklisted address: ${txs}`)
         writeError(res, 400, 'blacklisted tx')
         return
-      } else if (checkDistinctAddresses(txs)) {
+      } else if (checkDistinctAddresses(parsedTransactions)) {
         console.error(`bundle interacted with more than ${MAX_DISTINCT_TO} addresses`)
         writeError(res, 400, `bundle interacted with more than ${MAX_DISTINCT_TO} addresses`)
         return


### PR DESCRIPTION
Swaps out the account recovery method from the higher-level parseTransaction for the ethereumjs parser which does a lot less unnecessary processing while still supporting Berlin. Benchmarking shows a speed increase of 60-100x